### PR TITLE
Add NotSupportedError to service type check.

### DIFF
--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -6,6 +6,8 @@ import assert from 'assert-plus';
 import {getAppIdentity} from '@bedrock/app-identity';
 import rfdc from 'rfdc';
 
+const {util: {BedrockError}} = bedrock;
+
 const clone = rfdc();
 
 let APP_ID;
@@ -138,6 +140,10 @@ function generateInteractService({type, baseUrl, exchangeId, transactionId}) {
     const serviceEndpoint = `${baseUrl}?${searchParams.toString()}`;
     return {type, serviceEndpoint};
   }
-
-  throw new Error(`Unsupported service type: "${type}".`);
+  throw new BedrockError(
+    `Unsupported service type: "${type}".`,
+    'NotSupportedError', {
+      httpStatusCode: 400,
+      public: true
+    });
 }


### PR DESCRIPTION
Not sure if needed so just close if not. Was faster to just make the fix then ask.

This also means that an invalid service type should return `400` it returns `500` right now.