### PR TITLE
Update routes post continue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - **BREAKING**: Add json schema validators for `/exchanges/:exchangeId`.
 - **BREAKING**: Add json schema validators for `/exchanges/:exchangeId/:transactionId`.
 
+### Changed
+- **BREAKING**: Change method for `/exchanges/:exchangeId/:transactionId` to POST.
+
 ## 3.2.0 - 2022-08-12
 
 ### Changed

--- a/lib/http.js
+++ b/lib/http.js
@@ -55,7 +55,9 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
   app.post(
     routes.exchangeTransaction,
     cors(),
-    validate({bodySchema: getSchema({name: 'verifiablePresentation'})}),
+    validate({bodySchema: schemas.bodyWithVerifiablePresentation(getSchema({
+      name: 'verifiablePresentation'
+    }))}),
     asyncHandler(async (req, res) => {
       const {exchangeId} = req.params;
       const {
@@ -150,9 +152,9 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       const {exchangeInstance} = record;
       const step = _getStep({exchangeInstance, stepId});
       _ensureCapabilitiesForExchangeInstance({exchangeInstance, stepId});
-
+      const {capability} = step.data.verifiablePresentation;
       const promises = [];
-      Object.entries(step.data.capability).forEach(([referenceId, zcap]) => {
+      Object.entries(capability).forEach(([referenceId, zcap]) => {
         const promise = (async zcap => {
           return {
             referenceId,
@@ -205,7 +207,7 @@ function _getStep({exchangeInstance, stepId}) {
 
 function _ensureCapabilitiesForExchangeInstance({exchangeInstance, stepId}) {
   const step = exchangeInstance.steps[stepId];
-  if(!(step.data && step.data.capability)) {
+  if(!(step?.data && step.data?.verifiablePresentation?.capability)) {
     throw new BedrockError(
       'Invalid request for capability delegation.', 'DataError', {
         httpStatusCode: 400,

--- a/lib/http.js
+++ b/lib/http.js
@@ -52,7 +52,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     }));
 
   app.options(routes.exchangeTransaction, cors());
-  app.put(
+  app.post(
     routes.exchangeTransaction,
     cors(),
     validate({bodySchema: getSchema({name: 'verifiablePresentation'})}),

--- a/schemas/bedrock-vc-exchanger.js
+++ b/schemas/bedrock-vc-exchanger.js
@@ -23,6 +23,16 @@ const vpRequestWithQuery = {
   }
 };
 
+export const bodyWithVerifiablePresentation = vpSchema => ({
+  title: 'Request with a Verifiable Presentation',
+  type: 'object',
+  additionalItems: true,
+  required: ['verifiablePresentation'],
+  properties: {
+    verifiablePresentation: vpSchema
+  }
+});
+
 export const initiateExchange = {
   title: 'Initiate Exchange Request',
   anyOf: [object, vpRequestWithQuery]

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -67,7 +67,7 @@ describe('API', () => {
       const {interact} = initialResponse.data.verifiablePresentationRequest;
       shouldHaveInteractService({interact});
       const [interactService] = interact.service;
-      const interactResponse = await api.put({
+      const interactResponse = await api.post({
         path: interactService.serviceEndpoint,
         json: presentations.one
       });
@@ -91,7 +91,7 @@ describe('API', () => {
       const {interact} = initialResponse.data.verifiablePresentationRequest;
       shouldHaveInteractService({interact});
       const [interactService] = interact.service;
-      const interactResponse = await api.put({
+      const interactResponse = await api.post({
         path: interactService.serviceEndpoint + 'notFound',
         json: presentations.one
       });

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -122,7 +122,7 @@ describe('API', () => {
       const {interact} = initialResponse.data.verifiablePresentationRequest;
       shouldHaveInteractService({interact});
       const [interactService] = interact.service;
-      const interactResponse = await api.put({
+      const interactResponse = await api.post({
         path: interactService.serviceEndpoint,
         json: presentations.one
       });
@@ -162,7 +162,7 @@ describe('API', () => {
       const [interactService] = interact.service;
       const exampleZcap = await delegateRootZcap();
       presentations.two.capability.example = exampleZcap;
-      const interactResponse = await api.put({
+      const interactResponse = await api.post({
         path: interactService.serviceEndpoint,
         json: presentations.two
       });

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -69,7 +69,7 @@ describe('API', () => {
       const [interactService] = interact.service;
       const interactResponse = await api.post({
         path: interactService.serviceEndpoint,
-        json: presentations.one
+        json: {verifiablePresentation: {...presentations.one}}
       });
       shouldNotError({
         ...interactResponse,
@@ -93,7 +93,7 @@ describe('API', () => {
       const [interactService] = interact.service;
       const interactResponse = await api.post({
         path: interactService.serviceEndpoint + 'notFound',
-        json: presentations.one
+        json: {verifiablePresentation: {...presentations.one}}
       });
       //FIXME this should probably be 404 as the user is requesting
       // an incorrect instanceId
@@ -124,7 +124,7 @@ describe('API', () => {
       const [interactService] = interact.service;
       const interactResponse = await api.post({
         path: interactService.serviceEndpoint,
-        json: presentations.one
+        json: {verifiablePresentation: {...presentations.one}}
       });
       shouldNotError({
         ...interactResponse,
@@ -141,7 +141,11 @@ describe('API', () => {
         path: exchangePath,
         expected: {status: 200}
       });
-      exchangeStepResponse.data.should.eql(presentations.one);
+      exchangeStepResponse.data.should.eql({
+        verifiablePresentation: {
+          ...presentations.one
+        }
+      });
     });
   });
   describe(`${exchangeInstance}/:stepId/delegate`, () => {
@@ -164,7 +168,7 @@ describe('API', () => {
       presentations.two.capability.example = exampleZcap;
       const interactResponse = await api.post({
         path: interactService.serviceEndpoint,
-        json: presentations.two
+        json: {verifiablePresentation: {...presentations.two}}
       });
       shouldNotError({
         ...interactResponse,


### PR DESCRIPTION
Changes route `/exchanges/:exchangeId/:transactionId` to use POST instead of PUT.
Changes validator for `/exchanges/:exchangeId/:transactionId` to expect a json object of this form:

```js
{
  verifiablePresentation: {
    type: ['VerifiablePresentation']
  }
}
```