### PR TITLE
Upgrade to Node Mongo Driver 4 API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-vc-exchanger ChangeLog
 
+## 4.0.0 -
+
+### Changed
+- **BREAKING**: Changed usage of mongodb results to reflect Mongo Driver 4 API.
+- **BREAKING**: Upgrade to latest `@bedrock/mongodb`.
+
 ## 3.2.0 - 2022-08-12
 
 ### Changed

--- a/lib/exchangeInstance.js
+++ b/lib/exchangeInstance.js
@@ -294,8 +294,8 @@ async function _insert({exchangeInstanceId, exchangeId, ttl} = {}) {
   };
   try {
     const collection = database.collections[COLLECTION_NAME];
-    const result = await collection.insertOne(record);
-    return result.ops[0];
+    await collection.insertOne(record);
+    return record;
   } catch(e) {
     if(!database.isDuplicateError(e)) {
       throw e;

--- a/lib/exchangeInstance.js
+++ b/lib/exchangeInstance.js
@@ -60,14 +60,13 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
   await database.createIndexes([{
     collection: COLLECTION_NAME,
     fields: {'exchangeInstance.id': 1},
-    options: {unique: true, background: false}
+    options: {unique: true}
   }, {
     // automatically expire exchange instances
     collection: COLLECTION_NAME,
     fields: {'exchangeInstance.expires': 1},
     options: {
       unique: false,
-      background: false,
       expireAfterSeconds: 0
     }
   }]);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@bedrock/core": "^6.0.0",
     "@bedrock/express": "^8.0.0",
     "@bedrock/https-agent": "^4.0.0",
-    "@bedrock/mongodb": "^10.0.0"
+    "@bedrock/mongodb": "^11.0.0"
   },
   "devDependencies": {
     "eslint": "^8.18.0",

--- a/test/package.json
+++ b/test/package.json
@@ -15,7 +15,7 @@
     "@bedrock/core": "^6.0.0",
     "@bedrock/express": "^8.0.0",
     "@bedrock/https-agent": "^4.0.0",
-    "@bedrock/mongodb": "^10.0.0",
+    "@bedrock/mongodb": "github:digitalbazaar/bedrock-mongodb#mongo-driver-4-rc-fix-duplicate-error",
     "@bedrock/server": "^5.0.0",
     "@bedrock/test": "^8.0.0",
     "@bedrock/vc-exchanger": "file:..",


### PR DESCRIPTION
This library is being superseded by `@bedrock/vc-delivery`, but just in case it now works with latest `@bedrock/mongodb`.

Awaits:
- [ ] https://github.com/digitalbazaar/bedrock-mongodb/pull/92

Todo:
- [ ] Test with auth turned on in mongo server 6.
- [ ] Retest with releases to ensure peer deps work in npm >= 8
